### PR TITLE
Dont require user to repeat yourself with macro name

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,9 +46,6 @@ require "active_record"
 ```crystal
 class Person < ActiveRecord::Model
 
-  # Set model's name, should be unique throughout the application, mandatory
-  name Person
-
   # Set adapter, defaults to mysql (subject to change to postgres)
   # adapter sqlite
 

--- a/spec/active_record_spec.cr
+++ b/spec/active_record_spec.cr
@@ -63,7 +63,7 @@ class Person < ActiveRecord::Model
   end
 end
 
-class AnotherModel < ActiveRecord::Model
+class Another::Model < ActiveRecord::Model
   adapter null
   table_name something_else
 
@@ -146,7 +146,7 @@ module ActiveRecord
     describe ".fields" do
       it "returns fields defined on model" do
         Person.fields.should eq(["id", "last_name", "first_name", "number_of_dependents"])
-        AnotherModel.fields.should eq(["id", "name"])
+        Another::Model.fields.should eq(["id", "name"])
       end
     end
 
@@ -182,10 +182,10 @@ module ActiveRecord
         person.should_not eq(new_person.create)
         Person.get(person.id).should eq(person)
 
-        example = AnotherModel.new.create
+        example = Another::Model.new.create
         example.id.should_not be_a(Int::Null)
-        example.should_not eq(AnotherModel.new)
-        AnotherModel.get(example.id).should eq(example)
+        example.should_not eq(Another::Model.new)
+        Another::Model.get(example.id).should eq(example)
       end
 
       it "can be used through .create" do

--- a/spec/active_record_spec.cr
+++ b/spec/active_record_spec.cr
@@ -43,8 +43,6 @@ end
 class Example; end
 
 class Person < ActiveRecord::Model
-
-  name Person
   adapter null
   table_name people
 
@@ -63,23 +61,17 @@ class Person < ActiveRecord::Model
       "No person"
     end
   end
-
 end
 
 class AnotherModel < ActiveRecord::Model
-
-  name AnotherModel
   adapter null
   table_name something_else
 
   primary id :: Int
   field name :: String
-
 end
 
 class Post < ActiveRecord::Model
-
-  name Post
   adapter null
   table_name posts
 
@@ -99,8 +91,6 @@ class Post < ActiveRecord::Model
 end
 
 class ExampleModel < ActiveRecord::Model
-
-  name ExampleModel
   adapter fake
 
   primary  id    :: Int
@@ -108,8 +98,6 @@ class ExampleModel < ActiveRecord::Model
 end
 
 class AnotherExampleModel < ActiveRecord::Model
-
-  name AnotherExampleModel
   adapter fake
   table_name some_models
 

--- a/src/model.cr
+++ b/src/model.cr
@@ -123,10 +123,18 @@ module ActiveRecord
       define_field_macro({{level}})
     end
 
-    macro name(current_model)
+    # Deprecated and useless
+    macro name(_name)
+    end
+
+    macro initialize_model(current_model)
       {% MACRO_CURRENT << current_model %}
       MACRO_FIELDS_{{current_model.id}} = [] of String
       define_field_macro ""
+    end
+
+    macro inherited
+      initialize_model({{@type.name}})
     end
 
     private def self.register_field(name, its_type)

--- a/src/model.cr
+++ b/src/model.cr
@@ -134,7 +134,7 @@ module ActiveRecord
     end
 
     macro inherited
-      initialize_model({{@type.name}})
+      initialize_model({{@type.name.id.stringify.gsub(/:/, "__")}})
     end
 
     private def self.register_field(name, its_type)


### PR DESCRIPTION
closes waterlink/postgres_adapter.cr#1

This PR replaces ugly workaround for initializing the state of macro state to proper one using `macro included`.

/cc @sdogruyol 
