### PR TITLE
Add float type

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@
 .crystal/
 /shard.lock
 /.shards
+
+/.watch.out
+/.change-count

--- a/spec/types_spec.cr
+++ b/spec/types_spec.cr
@@ -18,52 +18,127 @@ module StuffGenerator
   end
 end
 
+macro test_non_null(ty, value, other_value, name="_", check_op="")
+context "when {{ty}} is not null" do
+  subject = {{value}} as SupportedType
+
+  it "has correct type" do
+    typeof(subject).should_not eq {{ty}}
+    typeof(subject).should eq SupportedType
+  end
+
+  it "is not null" do
+    subject.null?.should eq false
+  end
+
+  it "is possible to unwrap" do
+    subject.not_null!.should eq subject
+    subject.not_null!.should be_a({{ty}})
+    typeof(subject.not_null!).should eq NonNullType
+  end
+
+  it "has valid to_s implementation" do
+    subject.to_s.should eq({{value}}.to_s)
+  end
+
+  it "forwards calls to original value" do
+    {{name.id}} = subject as {{ty}}
+    ({{check_op.id}}).should eq(true)
+  end
+
+  it "implements correct == method" do
+    subject.should eq({{value}})
+    subject.should_not eq({{other_value}})
+    subject.should_not eq({{ty}}::Null.new)
+  end
+end
+end
+
+macro test_null(ty, zero, other_value, name="_", check_op="true")
+context "when {{ty}} is null" do
+  subject = {{ty}}::Null.new as SupportedType
+
+  it "has correct type" do
+    typeof(subject).should_not eq {{ty}}
+    typeof(subject).should eq SupportedType
+  end
+
+  it "is null" do
+    subject.null?.should eq true
+  end
+
+  it "is impossible to unwrap" do
+    typeof(subject.not_null!).should eq NonNullType
+    expect_raises(NullCheckFailed, /{{ty}}::Null/) do
+      subject.not_null!
+    end
+  end
+
+  it "has valid to_s implementation" do
+    subject.to_s.should eq("")
+  end
+
+  it "forwards calls to zero-like value" do
+    {{name.id}} = subject as {{ty}}::Null
+    ({{check_op.id}}).should eq(true)
+  end
+
+  it "implements correct == method" do
+    subject.should eq({{zero}})
+    subject.should_not eq({{other_value}})
+    subject.should eq({{ty}}::Null.new)
+  end
+end
+end
+
+macro test_comparable(ty, spec_ty, value, zero)
+it "implements correct Comparable" do
+  subject = {{value}} as SupportedType
+  null = {{ty}}::Null.new as SupportedType
+
+  ((subject as {{spec_ty}}) <=> {{zero}}).should eq({{value}} <=> {{zero}})
+  ((null as {{ty}}::Null) <=> {{value}}).should eq({{zero}} <=> {{value}})
+end
+end
+
 module ActiveRecord
   describe "supported types" do
-    describe "Int" do
-      it "is not null" do
-        subject = StuffGenerator.an_int
-        typeof(subject).should_not eq Int32
-        typeof(subject).should eq SupportedType
-        subject.null?.should eq false
-        subject.not_null!.should eq subject
-        typeof(subject.not_null!).should eq NonNullType
-      end
+    describe Int do
+      test_non_null Int8, 37_i8, 0, x, x + 5 == 42
+      test_non_null Int16, 37_i16, 0, x, x + 5 == 42
+      test_non_null Int32, 37_i32, 0, x, x + 5 == 42
+      test_non_null Int64, 37_i64, 0, x, x + 5 == 42
 
-      it "is null" do
-        subject = StuffGenerator.an_int_null
-        typeof(subject).should eq SupportedType
-        typeof(subject).should_not eq Int32
-        subject.null?.should eq true
-        typeof(subject.not_null!).should eq NonNullType
+      test_non_null UInt8, 37_u8, 0, x, x + 5 == 42
+      test_non_null UInt16, 37_u16, 0, x, x + 5 == 42
+      test_non_null UInt32, 37_u32, 0, x, x + 5 == 42
+      test_non_null UInt64, 37_u64, 0, x, x + 5 == 42
 
-        expect_raises(NullCheckFailed, /Int::Null/) do
-          subject.not_null!
-        end
-      end
+      test_null Int, 0, 37, x, x + 5 == 5
+
+      test_comparable Int, Int32, 37, 0
     end
 
-    describe "String" do
-      it "is not null" do
-        subject = StuffGenerator.a_string
-        typeof(subject).should_not eq String
-        typeof(subject).should eq SupportedType
-        subject.null?.should eq false
-        subject.not_null!.should eq subject
-        typeof(subject.not_null!).should eq NonNullType
-      end
+    describe String do
+      test_non_null String, "hello world", "", s, s + "!" == "hello world!"
+      test_null String, "", "some string", s, s + "stuff" == "stuff"
+    end
 
-      it "is null" do
-        subject = StuffGenerator.a_string_null
-        typeof(subject).should eq SupportedType
-        typeof(subject).should_not eq String
-        subject.null?.should eq true
-        typeof(subject.not_null!).should eq NonNullType
+    describe Time do
+      value = Time.new(2016, 2, 4, 17, 33, 29)
+      zero = Time.new(0)
 
-        expect_raises(NullCheckFailed, /String::Null/) do
-          subject.not_null!
-        end
-      end
+      test_non_null Time, value, zero, t,
+        t + 2.hours == Time.new(2016, 2, 4, 19, 33, 29)
+
+      test_null Time, zero, value, t, t + 1.day == zero + 1.day
+
+      test_comparable Time, Time, value, zero
+    end
+
+    describe Bool do
+      test_non_null Bool, true, false, x, !x == false
+      test_null Bool, false, true
     end
   end
 end

--- a/spec/types_spec.cr
+++ b/spec/types_spec.cr
@@ -140,5 +140,14 @@ module ActiveRecord
       test_non_null Bool, true, false, x, !x == false
       test_null Bool, false, true
     end
+
+    describe Float do
+      test_non_null Float32, 2.5_f32, 0.0, x, x + 5 == 7.5
+      test_non_null Float64, 2.5_f64, 0.0, x, x + 5 == 7.5
+
+      test_null Float, 0.0, 2.5_f32, x, x + 5 == 5.0
+
+      test_comparable Float, Float32, 2.5_f32, 0
+    end
   end
 end

--- a/src/model/fields.cr
+++ b/src/model/fields.cr
@@ -17,27 +17,14 @@ module ActiveRecord
       end
     end
 
-    # Int is the collection of integer fields
-    alias Int = Generic(IntTypes)
-
-    # String is the collection of string fields
-    alias String = Generic(StringTypes)
-
-    # Time is the collection of datetime fields
-    alias Time = Generic(TimeTypes)
-
-    # Bool is the collection of boolean fields
-    alias Bool = Generic(BoolTypes)
+    {% for group in TYPE_GROUPS %}
+      alias {{group.id}} = Generic({{group.id}}Types)
+    {% end %}
 
     private getter typed_fields
 
     def initialize
-      @typed_fields = {
-        "Int"    => Int.new,
-        "String" => String.new,
-        "Time"   => Time.new,
-        "Bool"   => Bool.new,
-      }
+      @typed_fields = init_typed_fields
     end
 
     # [] is for accessing fields collection of specific type
@@ -58,4 +45,12 @@ module ActiveRecord
       hash
     end
   end
+end
+
+private macro init_typed_fields
+  {
+    {% for group in TYPE_GROUPS %}
+      {{group.id.stringify}} => {{group.id}}.new,
+    {% end %}
+  }
 end

--- a/src/model/fields.cr
+++ b/src/model/fields.cr
@@ -1,13 +1,12 @@
 module ActiveRecord
   # Model::Fields represents collection of typed fields for model instance
   class Model::Fields
-    # Generic(T, V) represents collection of fields of type T with
-    # corresponding active record types V
-    class Generic(T, V)
+    # Generic(T) represents collection of fields of type T
+    class Generic(T)
       getter fields
 
       def initialize
-        @fields = {} of ::String => V
+        @fields = {} of ::String => T
       end
 
       def set_field(name, value)
@@ -19,16 +18,16 @@ module ActiveRecord
     end
 
     # Int is the collection of integer fields
-    alias Int = Generic(IntTypes, IntTypes)
+    alias Int = Generic(IntTypes)
 
     # String is the collection of string fields
-    alias String = Generic(::String, StringTypes)
+    alias String = Generic(StringTypes)
 
-    # TIme is the collection of datetime fields
-    alias Time = Generic(::Time, TimeTypes)
+    # Time is the collection of datetime fields
+    alias Time = Generic(TimeTypes)
 
     # Bool is the collection of boolean fields
-    alias Bool = Generic(::Bool, BoolTypes)
+    alias Bool = Generic(BoolTypes)
 
     private getter typed_fields
 

--- a/src/types.cr
+++ b/src/types.cr
@@ -112,11 +112,17 @@ ActiveRecord.define_not_null_for(:struct, Time, Time)
 ActiveRecord.register_type :struct, Bool, default: false
 ActiveRecord.define_not_null_for(:struct, Bool, Bool)
 
+ActiveRecord.register_type :struct, Float, default: 0.0, comparable: true
+ActiveRecord.define_not_null_for(:struct, Float, Float, register: false)
+ActiveRecord.define_not_null_for(:struct, Float, Float32)
+ActiveRecord.define_not_null_for(:struct, Float, Float64)
+
 module ActiveRecord
   alias_types Int
   alias_types String
   alias_types Time
   alias_types Bool
+  alias_types Float
 
   alias_types "*Supported*", true, SupportedType
   alias_types "*NonNull*", true, NonNullType

--- a/src/types.cr
+++ b/src/types.cr
@@ -119,7 +119,7 @@ struct Bool
     end
 
     def ==(other)
-      false
+      false == other
     end
 
     macro method_missing(name, args, block)

--- a/src/types.cr
+++ b/src/types.cr
@@ -23,7 +23,7 @@ module ActiveRecord
       {% end %}
   end
 
-  macro define_not_null_for(type, group, name, register=true)
+  macro register_type(type, group, name, register=true)
     {% ActiveRecord::SPEC_TYPES << {group, name} if register == true %}
 
     {{type.id}} {{name.id}}
@@ -51,7 +51,7 @@ module ActiveRecord
     {{:end.id}}
   end
 
-  macro register_type(kind, ty, default=nil, comparable=false, to_s="")
+  macro register_type_group(kind, ty, default=nil, comparable=false, to_s="")
     {{kind.id}} {{ty.id}}
       def self.null_class
         Null
@@ -92,30 +92,30 @@ module ActiveRecord
   end
 end
 
-ActiveRecord.register_type :struct, Int, default: 0, comparable: true
-ActiveRecord.define_not_null_for(:struct, Int, Int, register: false)
-ActiveRecord.define_not_null_for(:struct, Int, Int8)
-ActiveRecord.define_not_null_for(:struct, Int, UInt8)
-ActiveRecord.define_not_null_for(:struct, Int, Int16)
-ActiveRecord.define_not_null_for(:struct, Int, UInt16)
-ActiveRecord.define_not_null_for(:struct, Int, Int32)
-ActiveRecord.define_not_null_for(:struct, Int, UInt32)
-ActiveRecord.define_not_null_for(:struct, Int, Int64)
-ActiveRecord.define_not_null_for(:struct, Int, UInt64)
+ActiveRecord.register_type_group :struct, Int, default: 0, comparable: true
+ActiveRecord.register_type(:struct, Int, Int, register: false)
+ActiveRecord.register_type(:struct, Int, Int8)
+ActiveRecord.register_type(:struct, Int, UInt8)
+ActiveRecord.register_type(:struct, Int, Int16)
+ActiveRecord.register_type(:struct, Int, UInt16)
+ActiveRecord.register_type(:struct, Int, Int32)
+ActiveRecord.register_type(:struct, Int, UInt32)
+ActiveRecord.register_type(:struct, Int, Int64)
+ActiveRecord.register_type(:struct, Int, UInt64)
 
-ActiveRecord.register_type :class, String, default: ""
-ActiveRecord.define_not_null_for(:class, String, String)
+ActiveRecord.register_type_group :class, String, default: ""
+ActiveRecord.register_type(:class, String, String)
 
-ActiveRecord.register_type :struct, Time, default: Time.new(0), comparable: true
-ActiveRecord.define_not_null_for(:struct, Time, Time)
+ActiveRecord.register_type_group :struct, Time, default: Time.new(0), comparable: true
+ActiveRecord.register_type(:struct, Time, Time)
 
-ActiveRecord.register_type :struct, Bool, default: false
-ActiveRecord.define_not_null_for(:struct, Bool, Bool)
+ActiveRecord.register_type_group :struct, Bool, default: false
+ActiveRecord.register_type(:struct, Bool, Bool)
 
-ActiveRecord.register_type :struct, Float, default: 0.0, comparable: true
-ActiveRecord.define_not_null_for(:struct, Float, Float, register: false)
-ActiveRecord.define_not_null_for(:struct, Float, Float32)
-ActiveRecord.define_not_null_for(:struct, Float, Float64)
+ActiveRecord.register_type_group :struct, Float, default: 0.0, comparable: true
+ActiveRecord.register_type(:struct, Float, Float, register: false)
+ActiveRecord.register_type(:struct, Float, Float32)
+ActiveRecord.register_type(:struct, Float, Float64)
 
 module ActiveRecord
   alias_types Int

--- a/src/types.cr
+++ b/src/types.cr
@@ -1,149 +1,90 @@
-macro active_record_define_not_null_for(type, name)
-  {{type.id}} {{name.id}}
-    def not_null! : {{name}}
-      self as {{name}}
-    end
-
-    def null?
-      false
-    end
-
-    {{type.id}} Null
-      def not_null! : NoReturn
-        ::raise ActiveRecord::NullCheckFailed.new("It is {{name.id}}::Null")
-      end
-
-      def inspect
-        "Null(#{{{type.id.stringify}}})"
+module ActiveRecord
+  macro define_not_null_for(type, name)
+    {{type.id}} {{name.id}}
+      def not_null! : {{name}}
+        self as {{name}}
       end
 
       def null?
-        true
+        false
       end
+
+      {{type.id}} Null
+        def not_null! : NoReturn
+          ::raise ActiveRecord::NullCheckFailed.new("It is {{name.id}}::Null")
+        end
+
+        def inspect
+          "Null(#{{{type.id.stringify}}})"
+        end
+
+        def null?
+          true
+        end
+      {{:end.id}}
     {{:end.id}}
-  {{:end.id}}
-end
-
-struct Int
-  def self.null_class
-    Null
   end
 
-  struct Null
-    include Comparable(Int)
+  macro register_type(kind, ty, default=nil, comparable=false, to_s="")
+    {{kind.id}} {{ty.id}}
+      def self.null_class
+        Null
+      end
 
-    def to_s(io)
-      io << ""
-    end
+      def ==(other : Null)
+        self == {{default}}
+      end
 
-    macro method_missing(name, args, block)
-      0.{{name.id}}({{args.argify}}) {{block}}
-    end
-  end
+      {{kind.id}} Null
+        {% if comparable %}include Comparable({{ty.id}}){% end %}
 
-  include Comparable(Null)
+        def to_s(io)
+          io << {{to_s}}
+        end
 
-  def <=>(other : Null)
-    self <=> 0
-  end
-end
+        def ==(other : self)
+          true
+        end
 
-class String
-  def self.null_class
-    Null
-  end
+        def ==(other)
+          {{default}} == other
+        end
 
-  def ==(other : Null)
-    self == ""
-  end
+        macro method_missing(name, args, block)
+          {{default}}.\{{name.id}}(\{{args.argify}}) \{{block}}
+        end
+      {{:end.id}}
 
-  class Null
-    def to_s(io)
-      io << ""
-    end
+      {% if comparable %}
+        include Comparable({{ty.id}})
 
-    def ==(other : self)
-      true
-    end
-
-    def ==(other : String)
-      other == self
-    end
-
-    macro method_missing(name, args, block)
-      "".{{name.id}}({{args.argify}}) {{block}}
-    end
+        def <=>(other : Null)
+          self <=> {{default}}
+        end
+      {% end %}
+    {{:end.id}}
   end
 end
 
-struct Time
-  def self.null_class
-    Null
-  end
+ActiveRecord.register_type :struct, Int, default: 0, comparable: true
+ActiveRecord.define_not_null_for(:struct, Int)
+ActiveRecord.define_not_null_for(:struct, Int8)
+ActiveRecord.define_not_null_for(:struct, UInt8)
+ActiveRecord.define_not_null_for(:struct, Int16)
+ActiveRecord.define_not_null_for(:struct, UInt16)
+ActiveRecord.define_not_null_for(:struct, Int32)
+ActiveRecord.define_not_null_for(:struct, UInt32)
+ActiveRecord.define_not_null_for(:struct, Int64)
+ActiveRecord.define_not_null_for(:struct, UInt64)
 
-  struct Null
-    include Comparable(Time)
+ActiveRecord.register_type :class, String, default: ""
+ActiveRecord.define_not_null_for(:class, String)
 
-    def to_s(io)
-      io << ""
-    end
+ActiveRecord.register_type :struct, Time, default: Time.new(0), comparable: true
+ActiveRecord.define_not_null_for(:struct, Time)
 
-    macro method_missing(name, args, block)
-      Time.new(0).{{name.id}}({{args.argify}}) {{block}}
-    end
-  end
-
-  include Comparable(Null)
-
-  def <=>(other : Null)
-    self <=> Time.new(0)
-  end
-end
-
-struct Bool
-  def self.null_class
-    Null
-  end
-
-  def ==(other : Null)
-    false
-  end
-
-  struct Null
-    def to_s(io)
-      io << ""
-    end
-
-    def ==(other : self)
-      true
-    end
-
-    def ==(other)
-      false == other
-    end
-
-    macro method_missing(name, args, block)
-      false.{{name.id}}({{args.argify}}) {{block}}
-    end
-  end
-end
-
-active_record_define_not_null_for(:struct, Int)
-
-active_record_define_not_null_for(:struct, Int8)
-active_record_define_not_null_for(:struct, UInt8)
-active_record_define_not_null_for(:struct, Int16)
-active_record_define_not_null_for(:struct, UInt16)
-active_record_define_not_null_for(:struct, Int32)
-active_record_define_not_null_for(:struct, UInt32)
-active_record_define_not_null_for(:struct, Int64)
-active_record_define_not_null_for(:struct, UInt64)
-
-active_record_define_not_null_for(:class, String)
-
-active_record_define_not_null_for(:struct, Time)
-
-active_record_define_not_null_for(:struct, Bool)
+ActiveRecord.register_type :struct, Bool, default: false
+ActiveRecord.define_not_null_for(:struct, Bool)
 
 module ActiveRecord
   alias IntTypes = Int8 | UInt8 | Int16 | UInt16 | Int32 | UInt32 | Int64 | UInt64 | Int::Null

--- a/src/types.cr
+++ b/src/types.cr
@@ -1,8 +1,10 @@
 module ActiveRecord
   SPEC_TYPES = [] of Int32
+  TYPE_GROUPS = [] of Int32
 
   macro alias_types(group, special=false, as=nil)
     {% as = "#{group.id}Types".id unless as %}
+    {% TYPE_GROUPS << group unless special %}
 
     alias {{as.id}} =
       {% for x in SPEC_TYPES %}

--- a/src/types.cr
+++ b/src/types.cr
@@ -93,7 +93,7 @@ module ActiveRecord
 end
 
 ActiveRecord.register_type :struct, Int, default: 0, comparable: true
-ActiveRecord.define_not_null_for(:struct, Int, Int, register=false)
+ActiveRecord.define_not_null_for(:struct, Int, Int, register: false)
 ActiveRecord.define_not_null_for(:struct, Int, Int8)
 ActiveRecord.define_not_null_for(:struct, Int, UInt8)
 ActiveRecord.define_not_null_for(:struct, Int, Int16)

--- a/watch.sh
+++ b/watch.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+
+AUTO_COMMIT=${AUTO_COMMIT:-""}
+
+os="$(uname)"
+
+next_change() {
+  x=$(cat .change-count)
+  echo $((x+1)) | tee .change-count
+}
+
+watch() {
+  if [[ "$os" = "Linux" ]]; then
+    # to install: apt-get install inotify-tools
+    inotifywait --quiet --recursive --monitor --event modify --format "%w%f" "$@"
+  elif [[ "$os" = "Darwin" ]]; then
+    # to install: brew install fswatch
+    fswatch -o "$@"
+  else
+    echo "Unknown OS $os"
+    exit 1
+  fi
+}
+
+notify() {
+  if [[ "$os" = "Linux" ]]; then
+    notify-send "$@"
+  elif [[ "$os" = "Darwin" ]]; then
+    # to install: brew install terminal-notifier
+    if [[ "$1" == --expire-time=* ]]; then
+      shift
+    fi
+    echo terminal-notifier -message "$@"
+    terminal-notifier -message "$@"
+  else
+    echo "Unknown OS $os"
+    exit 1
+  fi
+}
+
+watch src spec \
+  | while read change; do
+    crystal spec --no-color > .watch.out
+    res=$?
+    committed=
+
+    if [[ $res -eq 0 ]]; then
+      ! [[ -z "$AUTO_COMMIT" ]] && git add . && git commit -m "[GREEN] Change $(next_change)" && committed="(committed)"
+      notify --expire-time=1000 "SUCCESS $committed"
+    else
+      failure=$(cat .watch.out | grep 'Failure\|expected:\|got:\|Error in')
+      cat .watch.out
+      ! [[ -z "$AUTO_COMMIT" ]] && git add . && git commit -m "[RED] Change $(next_change)" && committed="(committed)"
+      notify --expire-time=3000 "FAILURE:$failure $committed"
+    fi
+done


### PR DESCRIPTION
Fixes #38 

This PR:
1. Maximizes unit-test code coverage for existing types
2. De-duplicates unit-tests for existing types
3. De-duplicates `types.cr` module
4. Make `model/fields.cr` not know specifically what types exist, rather macro-loop over them
5. Adds float type, now very easy, and in one place: https://github.com/waterlink/active_record.cr/commit/985477b2f5e6ef3af0ed6c14ac2afcfba4fbea6b (well, in 2 places, because of TDD)

/cc @sdogruyol WDYT?
