### PR TITLE
Add connection pool

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,19 @@ Supported logic operators: `or | and & xor ^ not !`
 
 Supported is operators: `is_true is_not_true is_false is_not_false is_unknown is_not_unknown is_null is_not_null`
 
+### Connection Pool configuration (Experimental)
+
+Each distinct model class has its own associated connection pool. By default,
+pool capacity is 1 and timeout is 2 seconds. These settings can be changed on
+per model basis:
+
+```crystal
+class Person < ActiveRecord::Model
+  @@connection_pool_capacity = 25
+  @@connection_pool_timeout = 0.03  # seconds
+end
+```
+
 ### Joins (TODO)
 
 *This is still not implemented.*

--- a/shard.yml
+++ b/shard.yml
@@ -6,6 +6,11 @@ authors:
 
 license: MIT
 
+dependencies:
+  pool:
+    github: ysbaddaden/pool
+    version: 0.2.1
+
 development_dependencies:
   mocks:
     github: waterlink/mocks.cr


### PR DESCRIPTION
fixes #40 

This PR makes all models use class-scoped connection pool of database adapters.

I am adding it currently as an experimental feature, that is why, default behavior is to have connection pool of size = 1. It can be easily changed and specified in README, how to do it.

When I will be sure, that this will work as expected, we might as well want to provide some sort of configuration on default pool size. Related #30 

@sdogruyol Can you take a look?
