### PR TITLE
Crystal 0.15.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,7 +187,7 @@ criteria("subject_id").is_not_null                    # [(subject_id) IS NOT NUL
 
 Supported comparison operators: `== != > >= < <=`
 
-Supported logic operators: `or | and & xor ^ not !`
+Supported logic operators: `or | and & xor ^ not`
 
 Supported is operators: `is_true is_not_true is_false is_not_false is_unknown is_not_unknown is_null is_not_null`
 

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Add it to `shard.yml`:
 dependencies:
   active_record:
     github: waterlink/active_record.cr
-    version: 0.3.2
+    version: 0.4.0
 ```
 
 Additionally you would need to choose your database driver adapter. For

--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active_record
-version: 0.3.2
+version: 0.4.0
 
 authors:
 - Oleksii Fedorov <waterlink000@gmail.com>

--- a/spec/sql/query_generator_spec.cr
+++ b/spec/sql/query_generator_spec.cr
@@ -139,21 +139,17 @@ module ActiveRecord
           expected_query = Query["NOT (number < :1)", {"1" => 35}]
           generate(query).should eq(expected_query)
 
-          query = !(criteria("number") < 35)
-          expected_query = Query["NOT (number < :1)", {"1" => 35}]
-          generate(query).should eq(expected_query)
-
-          query = !(criteria("number") < 35).and(criteria("other_person") == 1)
+          query = ((criteria("number") < 35).and(criteria("other_person") == 1)).not
           expected_query = Query["NOT ((number < :1) AND (other_person = :2))",
             {"1" => 35, "2" => 1}]
           generate(query).should eq(expected_query)
 
-          query = (!(criteria("number") < 35)).and(criteria("other_person") == 1)
+          query = (criteria("number") < 35).not.and(criteria("other_person") == 1)
           expected_query = Query["(NOT (number < :1)) AND (other_person = :2)",
             {"1" => 35, "2" => 1}]
           generate(query).should eq(expected_query)
 
-          query = (criteria("number") < 35).and(!(criteria("other_person") == 1))
+          query = (criteria("number") < 35).and((criteria("other_person") == 1).not)
           expected_query = Query["(number < :1) AND (NOT (other_person = :2))",
             {"1" => 35, "2" => 1}]
           generate(query).should eq(expected_query)

--- a/src/query.cr
+++ b/src/query.cr
@@ -41,8 +41,6 @@ module ActiveRecord
       unary_op(Not)
     end
 
-    alias_operation :!, :not
-
     def is_true
       unary_op(IsTrue)
     end


### PR DESCRIPTION
It is no longer possible to override the behavior of unary `!` operator. Therefore we remove the alias for `#not` here.
