### PR TITLE
Defining the class variable @@query_generators outside of the module extension in the Adapter

### DIFF
--- a/shard.yml
+++ b/shard.yml
@@ -1,5 +1,5 @@
 name: active_record
-version: 0.4.2
+version: 0.4.3
 
 authors:
 - Oleksii Fedorov <waterlink000@gmail.com>

--- a/src/adapter.cr
+++ b/src/adapter.cr
@@ -17,6 +17,7 @@ module ActiveRecord
   end
 
   abstract class Adapter
+    @@query_generators = Array(QueryGenerator).new
     extend AdapterHelper
 
     def self.build(table_name, primary_field, fields, register = true)

--- a/src/null_adapter.cr
+++ b/src/null_adapter.cr
@@ -41,8 +41,6 @@ module ActiveRecord
       new(table_name, primary_field, fields, register)
     end
 
-    @@query_generators : Array(QueryGenerator)?
-
     def initialize(@table_name : String, @primary_field : String, @fields : Array(String), register = true)
       @last_id = 0
       @records = [] of Hash(String, ActiveRecord::SupportedType)


### PR DESCRIPTION
When another adapter such as Postgresql::Adapter inherits the compiler complains that it can't properly infer the type.

I will push the version bump of the postgresql_adapter as well to use 0.4.3.

I isolated the problem in [this snippet](https://play.crystal-lang.org/#/r/13ov).
